### PR TITLE
Cleanup tests

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -19,120 +19,8 @@ fn get_bar_label_position(view: &ChartView) -> Result<BarLabelPosition, Renderer
 mod tests {
     use super::*;
 
-    #[test]
-    fn get_bar_label_position_center() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: ChartViewBarLabelPosition::Center as i32,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: None,
-        };
-
-        assert_eq!(
-            BarLabelPosition::Center,
-            get_bar_label_position(&view).unwrap()
-        );
-    }
-
-    #[test]
-    fn get_bar_label_position_end_inside() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: ChartViewBarLabelPosition::EndInside as i32,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: None,
-        };
-
-        assert_eq!(
-            BarLabelPosition::EndInside,
-            get_bar_label_position(&view).unwrap()
-        );
-    }
-
-    #[test]
-    fn get_bar_label_position_end_outside() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: ChartViewBarLabelPosition::EndOutside as i32,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: None,
-        };
-
-        assert_eq!(
-            BarLabelPosition::EndOutside,
-            get_bar_label_position(&view).unwrap()
-        );
-    }
-
-    #[test]
-    fn get_bar_label_position_start_inside() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: ChartViewBarLabelPosition::StartInside as i32,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: None,
-        };
-
-        assert_eq!(
-            BarLabelPosition::StartInside,
-            get_bar_label_position(&view).unwrap()
-        );
-    }
-
-    #[test]
-    fn get_bar_label_position_start_outside() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: ChartViewBarLabelPosition::StartOutside as i32,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: None,
-        };
-
-        assert_eq!(
-            BarLabelPosition::StartOutside,
-            get_bar_label_position(&view).unwrap()
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    fn get_bar_label_position_unknown() {
-        let view = ChartView {
+    fn chart_view_empty() -> ChartView {
+        ChartView {
             kind: 0,
             x_scale: None,
             y_scale: None,
@@ -144,7 +32,68 @@ mod tests {
             point_label_visible: false,
             point_label_position: 0,
             values: None,
-        };
+        }
+    }
+
+    #[test]
+    fn get_bar_label_position_center() {
+        let mut view = chart_view_empty();
+        view.bar_label_position = ChartViewBarLabelPosition::Center as i32;
+
+        assert_eq!(
+            BarLabelPosition::Center,
+            get_bar_label_position(&view).unwrap()
+        );
+    }
+
+    #[test]
+    fn get_bar_label_position_end_inside() {
+        let mut view = chart_view_empty();
+        view.bar_label_position = ChartViewBarLabelPosition::EndInside as i32;
+
+        assert_eq!(
+            BarLabelPosition::EndInside,
+            get_bar_label_position(&view).unwrap()
+        );
+    }
+
+    #[test]
+    fn get_bar_label_position_end_outside() {
+        let mut view = chart_view_empty();
+        view.bar_label_position = ChartViewBarLabelPosition::EndOutside as i32;
+
+        assert_eq!(
+            BarLabelPosition::EndOutside,
+            get_bar_label_position(&view).unwrap()
+        );
+    }
+
+    #[test]
+    fn get_bar_label_position_start_inside() {
+        let mut view = chart_view_empty();
+        view.bar_label_position = ChartViewBarLabelPosition::StartInside as i32;
+
+        assert_eq!(
+            BarLabelPosition::StartInside,
+            get_bar_label_position(&view).unwrap()
+        );
+    }
+
+    #[test]
+    fn get_bar_label_position_start_outside() {
+        let mut view = chart_view_empty();
+        view.bar_label_position = ChartViewBarLabelPosition::StartOutside as i32;
+
+        assert_eq!(
+            BarLabelPosition::StartOutside,
+            get_bar_label_position(&view).unwrap()
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn get_bar_label_position_unknown() {
+        let view = chart_view_empty();
 
         get_bar_label_position(&view).unwrap();
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -100,8 +100,7 @@ mod tests {
             point_stroke_color: color_rgb(),
         };
 
-        let view_colors =
-            get_view_colors(Some(chart_view_colors)).expect("unable to get view colors");
+        let view_colors = get_view_colors(Some(chart_view_colors)).unwrap();
 
         assert_eq!(
             "#0E0C50".to_string(),

--- a/src/point.rs
+++ b/src/point.rs
@@ -32,9 +32,8 @@ fn get_point_type(view: &ChartView) -> Result<PointType, RendererError> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn get_point_label_position_top() {
-        let view = ChartView {
+    fn chart_view_empty() -> ChartView {
+        ChartView {
             kind: 0,
             x_scale: None,
             y_scale: None,
@@ -42,11 +41,17 @@ mod tests {
             bar_label_visible: false,
             bar_label_position: 0,
             point_visible: false,
-            point_type: 0,
+            point_type: ChartViewPointType::UnspecifiedPointType as i32,
             point_label_visible: false,
-            point_label_position: ChartViewPointLabelPosition::Top as i32,
+            point_label_position: ChartViewPointLabelPosition::UnspecifiedPointLabelPosition as i32,
             values: None,
-        };
+        }
+    }
+
+    #[test]
+    fn get_point_label_position_top() {
+        let mut view = chart_view_empty();
+        view.point_label_position = ChartViewPointLabelPosition::Top as i32;
 
         assert_eq!(
             PointLabelPosition::Top,
@@ -56,19 +61,8 @@ mod tests {
 
     #[test]
     fn get_point_label_position_top_left() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: ChartViewPointLabelPosition::TopLeft as i32,
-            values: None,
-        };
+        let mut view = chart_view_empty();
+        view.point_label_position = ChartViewPointLabelPosition::TopLeft as i32;
 
         assert_eq!(
             PointLabelPosition::TopLeft,
@@ -78,19 +72,8 @@ mod tests {
 
     #[test]
     fn get_point_label_position_top_right() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: ChartViewPointLabelPosition::TopRight as i32,
-            values: None,
-        };
+        let mut view = chart_view_empty();
+        view.point_label_position = ChartViewPointLabelPosition::TopRight as i32;
 
         assert_eq!(
             PointLabelPosition::TopRight,
@@ -100,19 +83,8 @@ mod tests {
 
     #[test]
     fn get_point_label_position_left() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: ChartViewPointLabelPosition::Left as i32,
-            values: None,
-        };
+        let mut view = chart_view_empty();
+        view.point_label_position = ChartViewPointLabelPosition::Left as i32;
 
         assert_eq!(
             PointLabelPosition::Left,
@@ -122,19 +94,8 @@ mod tests {
 
     #[test]
     fn get_point_label_position_right() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: ChartViewPointLabelPosition::Right as i32,
-            values: None,
-        };
+        let mut view = chart_view_empty();
+        view.point_label_position = ChartViewPointLabelPosition::Right as i32;
 
         assert_eq!(
             PointLabelPosition::Right,
@@ -144,19 +105,8 @@ mod tests {
 
     #[test]
     fn get_point_label_position_bottom() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: ChartViewPointLabelPosition::Bottom as i32,
-            values: None,
-        };
+        let mut view = chart_view_empty();
+        view.point_label_position = ChartViewPointLabelPosition::Bottom as i32;
 
         assert_eq!(
             PointLabelPosition::Bottom,
@@ -166,19 +116,8 @@ mod tests {
 
     #[test]
     fn get_point_label_position_bottom_left() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: ChartViewPointLabelPosition::BottomLeft as i32,
-            values: None,
-        };
+        let mut view = chart_view_empty();
+        view.point_label_position = ChartViewPointLabelPosition::BottomLeft as i32;
 
         assert_eq!(
             PointLabelPosition::BottomLeft,
@@ -188,19 +127,8 @@ mod tests {
 
     #[test]
     fn get_point_label_position_bottom_right() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: ChartViewPointLabelPosition::BottomRight as i32,
-            values: None,
-        };
+        let mut view = chart_view_empty();
+        view.point_label_position = ChartViewPointLabelPosition::BottomRight as i32;
 
         assert_eq!(
             PointLabelPosition::BottomRight,
@@ -211,76 +139,31 @@ mod tests {
     #[test]
     #[should_panic]
     fn get_point_label_position_unknown() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: ChartViewPointLabelPosition::UnspecifiedPointLabelPosition as i32,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: None,
-        };
+        let view = chart_view_empty();
 
         get_point_label_position(&view).unwrap();
     }
 
     #[test]
     fn get_point_type_circle() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: ChartViewPointType::Circle as i32,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: None,
-        };
+        let mut view = chart_view_empty();
+        view.point_type = ChartViewPointType::Circle as i32;
 
         assert_eq!(PointType::Circle, get_point_type(&view).unwrap());
     }
 
     #[test]
     fn get_point_type_square() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: ChartViewPointType::Square as i32,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: None,
-        };
+        let mut view = chart_view_empty();
+        view.point_type = ChartViewPointType::Square as i32;
 
         assert_eq!(PointType::Square, get_point_type(&view).unwrap());
     }
 
     #[test]
     fn get_point_type_x() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: ChartViewPointType::X as i32,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: None,
-        };
+        let mut view = chart_view_empty();
+        view.point_type = ChartViewPointType::X as i32;
 
         assert_eq!(PointType::X, get_point_type(&view).unwrap());
     }
@@ -288,19 +171,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn get_point_type_unknown() {
-        let view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: ChartViewPointType::UnspecifiedPointType as i32,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: None,
-        };
+        let view = chart_view_empty();
 
         get_point_type(&view).unwrap();
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -88,9 +88,8 @@ mod tests {
     use crate::proto::render::ChartElementColor;
     use lc_render::Color;
 
-    #[test]
-    fn get_scalar_values_basic() {
-        let chart_view = ChartView {
+    fn chart_view_empty() -> ChartView {
+        ChartView {
             kind: 0,
             x_scale: None,
             y_scale: None,
@@ -101,12 +100,18 @@ mod tests {
             point_type: 0,
             point_label_visible: false,
             point_label_position: 0,
-            values: Some(Values::ScalarValues(ChartViewScalarValues {
-                values: vec![1_f32, 2_f32],
-            })),
-        };
+            values: None,
+        }
+    }
 
-        let scalar_values = get_scalar_values(&chart_view).expect("unable to get scalar values");
+    #[test]
+    fn get_scalar_values_basic() {
+        let mut view = chart_view_empty();
+        view.values = Some(Values::ScalarValues(ChartViewScalarValues {
+            values: vec![1_f32, 2_f32],
+        }));
+
+        let scalar_values = get_scalar_values(&view).unwrap();
 
         assert_eq!(vec![1_f32, 2_f32], scalar_values);
     }
@@ -122,42 +127,31 @@ mod tests {
                 .set_stroke_color(Color::new_from_hex("#004F84")),
         ];
 
-        let chart_view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: Some(Values::BarsValues(ChartViewBarsValues {
-                bars_datasets: vec![
-                    BarsDataset {
-                        values: vec![1_f32, 2_f32],
-                        fill_color: Some(ChartElementColor {
-                            color_value: Some(ColorValue::ColorHex("#FA4988".to_string())),
-                        }),
-                        stroke_color: Some(ChartElementColor {
-                            color_value: Some(ColorValue::ColorHex("#9C0412".to_string())),
-                        }),
-                    },
-                    BarsDataset {
-                        values: vec![3_f32, 4_f32],
-                        fill_color: Some(ChartElementColor {
-                            color_value: Some(ColorValue::ColorHex("#A9DEF2".to_string())),
-                        }),
-                        stroke_color: Some(ChartElementColor {
-                            color_value: Some(ColorValue::ColorHex("#004F84".to_string())),
-                        }),
-                    },
-                ],
-            })),
-        };
+        let mut view = chart_view_empty();
+        view.values = Some(Values::BarsValues(ChartViewBarsValues {
+            bars_datasets: vec![
+                BarsDataset {
+                    values: vec![1_f32, 2_f32],
+                    fill_color: Some(ChartElementColor {
+                        color_value: Some(ColorValue::ColorHex("#FA4988".to_string())),
+                    }),
+                    stroke_color: Some(ChartElementColor {
+                        color_value: Some(ColorValue::ColorHex("#9C0412".to_string())),
+                    }),
+                },
+                BarsDataset {
+                    values: vec![3_f32, 4_f32],
+                    fill_color: Some(ChartElementColor {
+                        color_value: Some(ColorValue::ColorHex("#A9DEF2".to_string())),
+                    }),
+                    stroke_color: Some(ChartElementColor {
+                        color_value: Some(ColorValue::ColorHex("#004F84".to_string())),
+                    }),
+                },
+            ],
+        }));
 
-        let bars_values = get_bars_values(&chart_view).expect("unable to get bars values");
+        let bars_values = get_bars_values(&view).unwrap();
 
         for (i, bars_value) in bars_values.iter().enumerate() {
             assert_eq!(expected_bars_values[i].values(), bars_value.values());
@@ -174,24 +168,37 @@ mod tests {
 
     #[test]
     fn get_points_values_basic() {
-        let chart_view = ChartView {
-            kind: 0,
-            x_scale: None,
-            y_scale: None,
-            colors: None,
-            bar_label_visible: false,
-            bar_label_position: 0,
-            point_visible: false,
-            point_type: 0,
-            point_label_visible: false,
-            point_label_position: 0,
-            values: Some(Values::PointsValues(ChartViewPointsValues {
-                points: vec![Point { x: 1_f32, y: 2_f32 }, Point { x: 3_f32, y: 4_f32 }],
-            })),
-        };
+        let mut view = chart_view_empty();
+        view.values = Some(Values::PointsValues(ChartViewPointsValues {
+            points: vec![Point { x: 1_f32, y: 2_f32 }, Point { x: 3_f32, y: 4_f32 }],
+        }));
 
-        let points_values = get_points_values(&chart_view).expect("unable to get points values");
+        let points_values = get_points_values(&view).unwrap();
 
         assert_eq!(vec![(1_f32, 2_f32), (3_f32, 4_f32)], points_values);
+    }
+
+    #[test]
+    #[should_panic]
+    fn get_scalar_values_err() {
+        let view = chart_view_empty();
+
+        get_scalar_values(&view).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn get_bars_values_err() {
+        let view = chart_view_empty();
+
+        get_bars_values(&view).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn get_points_values_err() {
+        let view = chart_view_empty();
+
+        get_points_values(&view).unwrap();
     }
 }


### PR DESCRIPTION
Add helper functions to create empty chart views.

Use `unwrap()` instead of `expect()`.

Add tests for values helpers that should panic.