### PR TITLE
Implement ChartRenderer service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "http"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,9 +314,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lc-render"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3cee7b1d3376571b028c5907b4c7cf2a18844152edde65ba663e068c21ff6a"
+checksum = "542849d47e8fb4e3b0c01ac0ccc3098a220964ba831a380179938b99ea086478"
 dependencies = [
  "itertools 0.10.0",
  "svg",
@@ -283,9 +326,14 @@ dependencies = [
 name = "lc-renderer"
 version = "0.0.1"
 dependencies = [
+ "chrono",
  "lc-render",
  "prost",
  "prost-types",
+ "slog",
+ "slog-async",
+ "slog-json",
+ "tokio",
  "tonic",
  "tonic-build",
 ]
@@ -347,6 +395,41 @@ checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "percent-encoding"
@@ -530,10 +613,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "serde"
+version = "1.0.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+
+[[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+
+[[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+
+[[package]]
+name = "slog-async"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c60813879f820c85dbc4eabf3269befe374591289019775898d56a81a804fbdc"
+dependencies = [
+ "crossbeam-channel",
+ "slog",
+ "take_mut",
+ "thread_local",
+]
+
+[[package]]
+name = "slog-json"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "slog",
+]
 
 [[package]]
 name = "socket2"
@@ -563,6 +699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +719,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "tokio"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +748,7 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
+ "num_cpus",
  "pin-project-lite",
  "tokio-macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,14 @@ categories = ["graphics"]
 keywords = ["graphics"]
 
 [dependencies]
-lc-render = "0.2.2"
+chrono = "0.4"
+lc-render = "0.2.3"
 prost = "0.7"
 prost-types = "0.7"
+slog = "2.7"
+slog-async = "2.5"
+slog-json = "2.3"
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tonic = "0.4"
 
 [build-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,14 +69,33 @@ pub enum RendererError {
 
     /// View kind is unknown.
     ViewKindIsUnknown,
+
+    /// Chart axes are not specified.
+    ChartAxesAreNotSpecified,
+
+    /// Chart sizes are not specified.
+    ChartSizesAreNotSpecified,
+
+    /// Chart margins are not specified.
+    ChartMarginsAreNotSpecified,
+
+    /// Top axis is set but it's not of band or linear kind
+    TopAxisIsSetButItsNotBandOrLinear,
+
+    /// Bottom axis is set but it's not of band or linear kind
+    BottomAxisIsSetButItsNotBandOrLinear,
+
+    /// Left axis is set but it's not of band or linear kind
+    LeftAxisIsSetButItsNotBandOrLinear,
+
+    /// Right axis is set but it's not of band or linear kind
+    RightAxisIsSetButItsNotBandOrLinear,
 }
 
 impl std::fmt::Display for RendererError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &*self {
-            RendererError::RenderError(e) => {
-                format!("unable to render chart: {}", e.to_string()).fmt(f)
-            }
+            RendererError::RenderError(e) => e.fmt(f),
             RendererError::ViewColorsAreNotSpecified => {
                 "view colors should be specified".to_string().fmt(f)
             }
@@ -145,6 +164,35 @@ impl std::fmt::Display for RendererError {
                     .fmt(f)
             }
             RendererError::ViewKindIsUnknown => "view kind is unknown".to_string().fmt(f),
+            RendererError::ChartAxesAreNotSpecified => {
+                "chart axes should be specified".to_string().fmt(f)
+            }
+            RendererError::ChartSizesAreNotSpecified => {
+                "chart sizes should be specified".to_string().fmt(f)
+            }
+            RendererError::ChartMarginsAreNotSpecified => {
+                "chart mergins should be specified".to_string().fmt(f)
+            }
+            RendererError::TopAxisIsSetButItsNotBandOrLinear => {
+                "top axis is set but it's not of band or linear kind"
+                    .to_string()
+                    .fmt(f)
+            }
+            RendererError::BottomAxisIsSetButItsNotBandOrLinear => {
+                "bottom axis is set but it's not of band or linear kind"
+                    .to_string()
+                    .fmt(f)
+            }
+            RendererError::LeftAxisIsSetButItsNotBandOrLinear => {
+                "left axis is set but it's not of band or linear kind"
+                    .to_string()
+                    .fmt(f)
+            }
+            RendererError::RightAxisIsSetButItsNotBandOrLinear => {
+                "right axis is set but it's not of band or linear kind"
+                    .to_string()
+                    .fmt(f)
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,63 @@
+#[macro_use]
+extern crate slog;
+extern crate slog_async;
+extern crate slog_json;
+
+use crate::proto::render::chart_renderer_server::ChartRendererServer;
+use crate::renderer::RendererServer;
+use slog::{Drain, FnValue, PushFnValue, Record};
+use std::net::SocketAddr;
+use tonic::transport::Server;
+
 mod bar;
 mod color;
 mod error;
 mod point;
 mod proto;
+mod renderer;
 mod scale;
 mod value;
 mod view;
 
-fn main() {
-    println!("Hello, world!");
+const ENV_LC_RENDERER_ADDR: &str = "LC_RENDERER_ADDR";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Prepare logger.
+    let drain = slog_json::Json::new(std::io::stdout())
+        .set_pretty(false)
+        .add_key_value(o!(
+        "ts" => PushFnValue(move |_ : &Record, ser| {
+            ser.emit(chrono::Utc::now().to_rfc3339())
+        }),
+        "level" => FnValue(move |rinfo : &Record| {
+            rinfo.level().as_short_str()
+        }),
+        "msg" => PushFnValue(move |record : &Record, ser| {
+            ser.emit(record.msg())
+        }),
+        ))
+        .build()
+        .fuse();
+    let drain = slog_async::Async::new(drain).build().fuse();
+    let log = slog::Logger::root(drain, o!("version" => env!("CARGO_PKG_VERSION")));
+
+    // Configure server address from env.
+    let addr = std::env::var(ENV_LC_RENDERER_ADDR).expect(&*format!(
+        "unable to read {} env variable",
+        ENV_LC_RENDERER_ADDR
+    ));
+    let socket_addr: SocketAddr = addr
+        .parse()
+        .expect(&*format!("unable to use {} as socket address", addr));
+
+    // Start GRPC server.
+    info!(log, "Server is started"; "addr" => addr);
+    let renderer_server = RendererServer::new(log);
+    Server::builder()
+        .add_service(ChartRendererServer::new(renderer_server))
+        .serve(socket_addr)
+        .await?;
+
+    Ok(())
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,0 +1,179 @@
+use crate::error::RendererError;
+use crate::proto::render::chart_renderer_server::ChartRenderer;
+use crate::proto::render::chart_scale::ChartScaleKind;
+use crate::proto::render::{RenderChartReply, RenderChartRequest};
+use crate::scale::{
+    get_band_h_scale, get_band_v_scale, get_h_scale, get_linear_h_scale, get_linear_v_scale,
+    get_v_scale,
+};
+use crate::view::get_views;
+use lc_render::Chart;
+use tonic::{Request, Response, Status};
+
+const ERR_UNABLE_TO_RENDER_CHART: &str = "Unable to render chart";
+
+const LOG_KEY_ERR: &str = "err";
+const LOG_KEY_REQ_ID: &str = "request_id";
+
+#[derive(Debug)]
+pub struct RendererServer {
+    log: slog::Logger,
+}
+
+impl RendererServer {
+    pub(crate) fn new(log: slog::Logger) -> RendererServer {
+        RendererServer { log }
+    }
+}
+
+#[tonic::async_trait]
+impl ChartRenderer for RendererServer {
+    async fn render_chart(
+        &self,
+        request: Request<RenderChartRequest>,
+    ) -> Result<Response<RenderChartReply>, Status> {
+        // Convert a request into RenderChartRequest.
+        let r_req = request.into_inner();
+
+        // Prepare request logger with request_id set.
+        let log = self.log.new(o!(LOG_KEY_REQ_ID => r_req.request_id.clone()));
+
+        // Get the needed parts that are required to render a chart.
+        let axes = match r_req.axes {
+            Some(axes) => axes,
+            None => {
+                let err = RendererError::ChartAxesAreNotSpecified.to_string();
+                error!(log, "{}", ERR_UNABLE_TO_RENDER_CHART; LOG_KEY_ERR => err.clone());
+                return Err(Status::invalid_argument(err));
+            }
+        };
+        let h_scale = match get_h_scale(&axes) {
+            Ok(h_scale) => h_scale,
+            Err(err) => {
+                let err = err.to_string();
+                error!(log, "{}", ERR_UNABLE_TO_RENDER_CHART; LOG_KEY_ERR => err.clone());
+                return Err(Status::invalid_argument(err));
+            }
+        };
+        let v_scale = match get_v_scale(&axes) {
+            Ok(v_scale) => v_scale,
+            Err(err) => {
+                let err = err.to_string();
+                error!(log, "{}", ERR_UNABLE_TO_RENDER_CHART; LOG_KEY_ERR => err.clone());
+                return Err(Status::invalid_argument(err));
+            }
+        };
+        let sizes = match r_req.sizes {
+            Some(sizes) => sizes,
+            None => {
+                let err = RendererError::ChartSizesAreNotSpecified.to_string();
+                error!(log, "{}", ERR_UNABLE_TO_RENDER_CHART; LOG_KEY_ERR => err.clone());
+                return Err(Status::invalid_argument(err));
+            }
+        };
+        let margins = match r_req.margins {
+            Some(margins) => margins,
+            None => {
+                let err = RendererError::ChartMarginsAreNotSpecified.to_string();
+                error!(log, "{}", ERR_UNABLE_TO_RENDER_CHART; LOG_KEY_ERR => err.clone());
+                return Err(Status::invalid_argument(err));
+            }
+        };
+        let chart_views = match get_views(&r_req.views, &sizes, &margins, &h_scale, &v_scale) {
+            Ok(chart_views) => chart_views,
+            Err(err) => {
+                let err = err.to_string();
+                error!(log, "{}", ERR_UNABLE_TO_RENDER_CHART; LOG_KEY_ERR => err.clone());
+                return Err(Status::invalid_argument(err));
+            }
+        };
+
+        // Prepare a chart.
+        let mut chart = Chart::new()
+            .set_width(sizes.width)
+            .set_height(sizes.height)
+            .set_margin_top(margins.margin_top)
+            .set_margin_bottom(margins.margin_bottom)
+            .set_margin_left(margins.margin_left)
+            .set_margin_right(margins.margin_right)
+            .set_title(&r_req.title)
+            .set_views(chart_views.iter().map(Box::as_ref).collect());
+
+        // Set the needed top axis.
+        chart = match axes.axis_top {
+            Some(_) => match ChartScaleKind::from_i32(h_scale.kind) {
+                Some(ChartScaleKind::Band) => chart
+                    .set_axis_top_band(get_band_h_scale(&h_scale, &sizes, &margins))
+                    .set_axis_top_label(&*axes.axis_top_label),
+                Some(ChartScaleKind::Linear) => chart
+                    .set_axis_top_linear(get_linear_h_scale(&h_scale, &sizes, &margins))
+                    .set_axis_top_label(&*axes.axis_top_label),
+                _ => {
+                    let err = RendererError::TopAxisIsSetButItsNotBandOrLinear.to_string();
+                    error!(log, "{}", ERR_UNABLE_TO_RENDER_CHART; LOG_KEY_ERR => err.clone());
+                    return Err(Status::invalid_argument(err));
+                }
+            },
+            _ => chart,
+        };
+
+        // Set the needed bottom axis.
+        chart = match axes.axis_bottom {
+            Some(_) => match ChartScaleKind::from_i32(h_scale.kind) {
+                Some(ChartScaleKind::Band) => chart
+                    .set_axis_bottom_band(get_band_h_scale(&h_scale, &sizes, &margins))
+                    .set_axis_bottom_label(&*axes.axis_bottom_label),
+                Some(ChartScaleKind::Linear) => chart
+                    .set_axis_bottom_linear(get_linear_h_scale(&h_scale, &sizes, &margins))
+                    .set_axis_bottom_label(&*axes.axis_bottom_label),
+                _ => {
+                    let err = RendererError::BottomAxisIsSetButItsNotBandOrLinear.to_string();
+                    error!(log, "{}", ERR_UNABLE_TO_RENDER_CHART; LOG_KEY_ERR => err.clone());
+                    return Err(Status::invalid_argument(err));
+                }
+            },
+            _ => chart,
+        };
+
+        // Set the needed left axis.
+        chart = match axes.axis_left {
+            Some(_) => match ChartScaleKind::from_i32(v_scale.kind) {
+                Some(ChartScaleKind::Band) => chart
+                    .set_axis_left_band(get_band_v_scale(&v_scale, &sizes, &margins))
+                    .set_axis_left_label(&*axes.axis_left_label),
+                Some(ChartScaleKind::Linear) => chart
+                    .set_axis_left_linear(get_linear_v_scale(&v_scale, &sizes, &margins))
+                    .set_axis_left_label(&*axes.axis_left_label),
+                _ => {
+                    let err = RendererError::LeftAxisIsSetButItsNotBandOrLinear.to_string();
+                    error!(log, "{}", ERR_UNABLE_TO_RENDER_CHART; LOG_KEY_ERR => err.clone());
+                    return Err(Status::invalid_argument(err));
+                }
+            },
+            _ => chart,
+        };
+
+        // Set the needed right axis.
+        chart = match axes.axis_right {
+            Some(_) => match ChartScaleKind::from_i32(v_scale.kind) {
+                Some(ChartScaleKind::Band) => chart
+                    .set_axis_right_band(get_band_v_scale(&v_scale, &sizes, &margins))
+                    .set_axis_right_label(&*axes.axis_right_label),
+                Some(ChartScaleKind::Linear) => chart
+                    .set_axis_right_linear(get_linear_v_scale(&v_scale, &sizes, &margins))
+                    .set_axis_right_label(&*axes.axis_right_label),
+                _ => {
+                    let err = RendererError::RightAxisIsSetButItsNotBandOrLinear.to_string();
+                    error!(log, "{}", ERR_UNABLE_TO_RENDER_CHART; LOG_KEY_ERR => err.clone());
+                    return Err(Status::invalid_argument(err));
+                }
+            },
+            _ => chart,
+        };
+
+        Ok(Response::new(RenderChartReply {
+            request_id: r_req.request_id,
+            chart_data: chart.to_svg().to_string().into_bytes(),
+        }))
+    }
+}


### PR DESCRIPTION
Add `RendererServer` that implements lc-proto `ChartRenderer`.

Rewrite `main` function to configure and start `RendererServer`.

Cleanup `RendererError::RenderError` message.

Implement JSON structured logging with `slog_json`.

Update `lc-render` to `v0.2.3`.

Add `tokio` dependency as the async runtime.