### PR TITLE
Fail on clippy warnings

### DIFF
--- a/.github/workflows/inspection.yml
+++ b/.github/workflows/inspection.yml
@@ -43,4 +43,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features
+          args: --all-targets --all-features -- -D warnings


### PR DESCRIPTION
Add `-- -D warnings` to inspection workflow.