### PR TITLE
Fix image tag for stable image

### DIFF
--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/limpidchart/lc-renderer:${{ github.ref }}
+            ghcr.io/limpidchart/lc-renderer:${GITHUB_REF##*/}
             ghcr.io/limpidchart/lc-renderer:latest


### PR DESCRIPTION
Use the actual tag name instead of `refs/tags/vX.Y.Z`.