### PR TITLE
Add prep stage to image release build

### DIFF
--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -8,10 +8,13 @@ on:
 jobs:
   build-and-publish-release:
     runs-on: ubuntu-latest
-    env:
-      IMAGE_TAG: ${{GITHUB_REF##*/}}
     steps:
       - uses: actions/checkout@v2
+
+      - id: prep
+        run: |
+          image_tag=${GITHUB_REF##*/}
+          echo "::set-output name=IMAGE_TAG::${image_tag}"
 
       - uses: docker/login-action@v1
         with:
@@ -23,5 +26,5 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/limpidchart/lc-renderer:${{IMAGE_TAG}}
+            ghcr.io/limpidchart/lc-renderer:${{ steps.prep.outputs.IMAGE_TAG }}
             ghcr.io/limpidchart/lc-renderer:latest


### PR DESCRIPTION
Add prep stage to get image tag.

Use output of that stage in `docker/build-push-action@v2`.