### PR TITLE
Fix and cleanup Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.52 as builder
+FROM rust:1 as builder
 
 WORKDIR ./lc-renderer
 COPY . .
@@ -10,8 +10,6 @@ FROM debian:stable-slim
 
 ARG LC_RENDERER_DIR=/opt/lc-renderer
 ARG LC_RENDERER_USER=lc-renderer
-ARG LC_RENDERER_IP=0.0.0.0
-ARG LC_RENDERER_PORT=54010
 
 RUN apt-get update \
     && apt-get -y upgrade \
@@ -20,17 +18,17 @@ RUN apt-get update \
 
 RUN groupadd $LC_RENDERER_USER \
     && useradd -g $LC_RENDERER_USER $LC_RENDERER_USER \
-    && mkdir -p ${LC_RENDERER_DIR}
+    && mkdir -p $LC_RENDERER_DIR
 
-COPY --from=builder /lc-renderer/target/release/lc-renderer ${LC_RENDERER_DIR}/lc-renderer
+COPY --from=builder /lc-renderer/target/release/lc-renderer $LC_RENDERER_DIR/lc-renderer
 
-RUN chown -R $LC_RENDERER_USER:$LC_RENDERER_USER ${LC_RENDERER_DIR}
+RUN chown -R $LC_RENDERER_USER:$LC_RENDERER_USER $LC_RENDERER_DIR
 
 EXPOSE $LC_RENDERER_PORT
 
-ENV LC_RENDERER_ADDR=$LC_RENDERER_IP:$LC_RENDERER_PORT
+ENV LC_RENDERER_ADDR=0.0.0.0:54020
 
 USER $LC_RENDERER_USER
-WORKDIR ${LC_RENDERER_DIR}
+WORKDIR $LC_RENDERER_DIR
 
 CMD ["./lc-renderer"]


### PR DESCRIPTION
Configure LC_RENDERER_ADDR via ENV and remove unused ARG.

Use `rust:1`.

Use `54020` as default port.