### PR TITLE
Disable fail-fast in inspection workflow

### DIFF
--- a/.github/workflows/inspection.yml
+++ b/.github/workflows/inspection.yml
@@ -10,6 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable


### PR DESCRIPTION
Always run all inspection jobs.