### PR TITLE
Update lc-proto to v0.4.0, fix colors, tune linters

### DIFF
--- a/.github/workflows/inspection-beta.yml
+++ b/.github/workflows/inspection-beta.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features -- -D warnings
+          args: --all-targets --all-features -- -D warnings -A clippy::enum_variant_names

--- a/.github/workflows/inspection-nightly.yml
+++ b/.github/workflows/inspection-nightly.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features -- -D warnings
+          args: --all-targets --all-features -- -D warnings -A clippy::enum_variant_names

--- a/.github/workflows/inspection-stable.yml
+++ b/.github/workflows/inspection-stable.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features -- -D warnings
+          args: --all-targets --all-features -- -D warnings -A clippy::enum_variant_names

--- a/proto/render/v0/view.proto
+++ b/proto/render/v0/view.proto
@@ -87,14 +87,14 @@ message ChartView {
 // ChartViewColors represents options to configure view colors.
 message ChartViewColors {
   // View fill color.
-  ChartElementColor fill_color = 1;
+  ChartElementColor fill = 1;
 
   // View stroke color.
-  ChartElementColor stroke_color = 2;
+  ChartElementColor stroke = 2;
 
   // View point fill color.
-  ChartElementColor point_fill_color = 3;
+  ChartElementColor point_fill = 3;
 
   // View point stroke color.
-  ChartElementColor point_stroke_color = 4;
+  ChartElementColor point_stroke = 4;
 }

--- a/proto/render/v0/view_values.proto
+++ b/proto/render/v0/view_values.proto
@@ -6,13 +6,18 @@ option go_package = "github.com/limpidchart/lc-proto/render/v0;render";
 
 import "color.proto";
 
-// ChartViewBarsValues represents options for bar values.
+// ChartViewBarsValues represents options for bars values.
 message ChartViewBarsValues {
+  // ChartViewBarsColors represents options to configure bars values colors.
+  message ChartViewBarsColors {
+    ChartElementColor fill = 1;
+    ChartElementColor stroke = 2;
+  }
+
   // BarsDataset represents a single dataset with several bars.
   message BarsDataset {
     repeated float values = 1;
-    ChartElementColor fill_color = 2;
-    ChartElementColor stroke_color = 3;
+    ChartViewBarsColors colors = 2;
   }
 
   // Array of configured bars datasets.

--- a/scripts/get_lc_proto.sh
+++ b/scripts/get_lc_proto.sh
@@ -6,7 +6,7 @@
 set -eu
 set -o pipefail
 
-LC_PROTO_VESION="v0.3.1"
+LC_PROTO_VESION="v0.4.0"
 
 LC_PROTO_URL="https://github.com/limpidchart/lc-proto.git"
 PROTOS_SRC_DIR="render"

--- a/src/color.rs
+++ b/src/color.rs
@@ -36,10 +36,10 @@ pub(crate) fn get_view_colors(
 
     match chart_view_colors {
         Some(chart_view_colors) => {
-            fill_color = get_color(chart_view_colors.fill_color);
-            stroke_color = get_color(chart_view_colors.stroke_color);
-            point_fill_color = get_color(chart_view_colors.point_fill_color);
-            point_stroke_color = get_color(chart_view_colors.point_stroke_color);
+            fill_color = get_color(chart_view_colors.fill);
+            stroke_color = get_color(chart_view_colors.stroke);
+            point_fill_color = get_color(chart_view_colors.point_fill);
+            point_stroke_color = get_color(chart_view_colors.point_stroke);
         }
         None => return Err(RendererError::ViewColorsAreNotSpecified),
     }
@@ -94,10 +94,10 @@ mod tests {
     #[test]
     fn get_colors_basic() {
         let chart_view_colors = ChartViewColors {
-            fill_color: color_hex(),
-            stroke_color: color_rgb(),
-            point_fill_color: color_hex(),
-            point_stroke_color: color_rgb(),
+            fill: color_hex(),
+            stroke: color_rgb(),
+            point_fill: color_hex(),
+            point_stroke: color_rgb(),
         };
 
         let view_colors = get_view_colors(Some(chart_view_colors)).unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,9 @@ pub enum RendererError {
     /// Expected points values but got other kind.
     ExpectedPointsValues,
 
+    /// Bars values are not specified.
+    ColorsForBarsValuesAreNotSpecified,
+
     /// Bars values fill color is not specified.
     FillColorForBarsValuesIsNotSpecified,
 
@@ -171,6 +174,11 @@ impl std::fmt::Display for RendererError {
             RendererError::ExpectedBarsValues => "expected bars values for view".to_string().fmt(f),
             RendererError::ExpectedPointsValues => {
                 "expected points values for view".to_string().fmt(f)
+            }
+            RendererError::ColorsForBarsValuesAreNotSpecified => {
+                "colors for bars values are not specified"
+                    .to_string()
+                    .fmt(f)
             }
             RendererError::FillColorForBarsValuesIsNotSpecified => {
                 "fill color for bars values is not specified"

--- a/src/proto/render.rs
+++ b/src/proto/render.rs
@@ -145,7 +145,7 @@ pub mod chart_element_color {
         ColorRgb(Rgb),
     }
 }
-/// ChartViewBarsValues represents options for bar values.
+/// ChartViewBarsValues represents options for bars values.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChartViewBarsValues {
     /// Array of configured bars datasets.
@@ -154,15 +154,21 @@ pub struct ChartViewBarsValues {
 }
 /// Nested message and enum types in `ChartViewBarsValues`.
 pub mod chart_view_bars_values {
+    /// ChartViewBarsColors represents options to configure bars values colors.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ChartViewBarsColors {
+        #[prost(message, optional, tag = "1")]
+        pub fill: ::core::option::Option<super::ChartElementColor>,
+        #[prost(message, optional, tag = "2")]
+        pub stroke: ::core::option::Option<super::ChartElementColor>,
+    }
     /// BarsDataset represents a single dataset with several bars.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BarsDataset {
         #[prost(float, repeated, tag = "1")]
         pub values: ::prost::alloc::vec::Vec<f32>,
         #[prost(message, optional, tag = "2")]
-        pub fill_color: ::core::option::Option<super::ChartElementColor>,
-        #[prost(message, optional, tag = "3")]
-        pub stroke_color: ::core::option::Option<super::ChartElementColor>,
+        pub colors: ::core::option::Option<ChartViewBarsColors>,
     }
 }
 /// ChartViewPointsValues represents options for point values.
@@ -284,16 +290,16 @@ pub mod chart_view {
 pub struct ChartViewColors {
     /// View fill color.
     #[prost(message, optional, tag = "1")]
-    pub fill_color: ::core::option::Option<ChartElementColor>,
+    pub fill: ::core::option::Option<ChartElementColor>,
     /// View stroke color.
     #[prost(message, optional, tag = "2")]
-    pub stroke_color: ::core::option::Option<ChartElementColor>,
+    pub stroke: ::core::option::Option<ChartElementColor>,
     /// View point fill color.
     #[prost(message, optional, tag = "3")]
-    pub point_fill_color: ::core::option::Option<ChartElementColor>,
+    pub point_fill: ::core::option::Option<ChartElementColor>,
     /// View point stroke color.
     #[prost(message, optional, tag = "4")]
-    pub point_stroke_color: ::core::option::Option<ChartElementColor>,
+    pub point_stroke: ::core::option::Option<ChartElementColor>,
 }
 /// RenderChartRequest represents chart rendering request.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/value.rs
+++ b/src/value.rs
@@ -39,11 +39,15 @@ pub(crate) fn get_bars_values(view: &ChartView) -> Result<Vec<BarsValues>, Rende
 
     let mut res = Vec::with_capacity(chart_view_bars_values.bars_datasets.len());
     for bars_value in chart_view_bars_values.bars_datasets.iter() {
-        let fill_color = match get_color(bars_value.fill_color.clone()) {
+        let colors = match bars_value.colors.clone() {
+            Some(colors) => colors,
+            None => return Err(RendererError::ColorsForBarsValuesAreNotSpecified),
+        };
+        let fill_color = match get_color(colors.fill.clone()) {
             Some(fill_color) => fill_color,
             None => return Err(RendererError::FillColorForBarsValuesIsNotSpecified),
         };
-        let stroke_color = match get_color(bars_value.stroke_color.clone()) {
+        let stroke_color = match get_color(colors.stroke.clone()) {
             Some(stroke_color) => stroke_color,
             None => return Err(RendererError::StrokeColorForBarsValuesIsNotSpecified),
         };
@@ -83,7 +87,7 @@ pub(crate) fn get_points_values(view: &ChartView) -> Result<Vec<(f32, f32)>, Ren
 mod tests {
     use super::*;
     use crate::proto::render::chart_element_color::ColorValue;
-    use crate::proto::render::chart_view_bars_values::BarsDataset;
+    use crate::proto::render::chart_view_bars_values::{BarsDataset, ChartViewBarsColors};
     use crate::proto::render::chart_view_points_values::Point;
     use crate::proto::render::ChartElementColor;
     use lc_render::Color;
@@ -130,20 +134,24 @@ mod tests {
             bars_datasets: vec![
                 BarsDataset {
                     values: vec![1_f32, 2_f32],
-                    fill_color: Some(ChartElementColor {
-                        color_value: Some(ColorValue::ColorHex("#FA4988".to_string())),
-                    }),
-                    stroke_color: Some(ChartElementColor {
-                        color_value: Some(ColorValue::ColorHex("#9C0412".to_string())),
+                    colors: Some(ChartViewBarsColors {
+                        fill: Some(ChartElementColor {
+                            color_value: Some(ColorValue::ColorHex("#FA4988".to_string())),
+                        }),
+                        stroke: Some(ChartElementColor {
+                            color_value: Some(ColorValue::ColorHex("#9C0412".to_string())),
+                        }),
                     }),
                 },
                 BarsDataset {
                     values: vec![3_f32, 4_f32],
-                    fill_color: Some(ChartElementColor {
-                        color_value: Some(ColorValue::ColorHex("#A9DEF2".to_string())),
-                    }),
-                    stroke_color: Some(ChartElementColor {
-                        color_value: Some(ColorValue::ColorHex("#004F84".to_string())),
+                    colors: Some(ChartViewBarsColors {
+                        fill: Some(ChartElementColor {
+                            color_value: Some(ColorValue::ColorHex("#A9DEF2".to_string())),
+                        }),
+                        stroke: Some(ChartElementColor {
+                            color_value: Some(ColorValue::ColorHex("#004F84".to_string())),
+                        }),
                     }),
                 },
             ],

--- a/src/view.rs
+++ b/src/view.rs
@@ -276,7 +276,7 @@ mod tests {
     use crate::proto::render::chart_view::{
         ChartViewBarLabelPosition, ChartViewPointLabelPosition, ChartViewPointType, Values,
     };
-    use crate::proto::render::chart_view_bars_values::BarsDataset;
+    use crate::proto::render::chart_view_bars_values::{BarsDataset, ChartViewBarsColors};
     use crate::proto::render::chart_view_points_values::Point;
     use crate::proto::render::{
         ChartElementColor, ChartViewBarsValues, ChartViewColors, ChartViewPointsValues,
@@ -285,16 +285,16 @@ mod tests {
 
     fn chart_view_colors() -> ChartViewColors {
         ChartViewColors {
-            fill_color: Some(ChartElementColor {
+            fill: Some(ChartElementColor {
                 color_value: Some(ColorValue::ColorHex("#2b4b49".to_string())),
             }),
-            stroke_color: Some(ChartElementColor {
+            stroke: Some(ChartElementColor {
                 color_value: Some(ColorValue::ColorHex("#226974".to_string())),
             }),
-            point_fill_color: Some(ChartElementColor {
+            point_fill: Some(ChartElementColor {
                 color_value: Some(ColorValue::ColorHex("#1a888b".to_string())),
             }),
-            point_stroke_color: Some(ChartElementColor {
+            point_stroke: Some(ChartElementColor {
                 color_value: Some(ColorValue::ColorHex("#50c5b6".to_string())),
             }),
         }
@@ -363,11 +363,13 @@ mod tests {
         view.values = Some(Values::BarsValues(ChartViewBarsValues {
             bars_datasets: vec![BarsDataset {
                 values: vec![16_f32, 32_f32],
-                fill_color: Some(ChartElementColor {
-                    color_value: Some(ColorValue::ColorHex("#a496c4".to_string())),
-                }),
-                stroke_color: Some(ChartElementColor {
-                    color_value: Some(ColorValue::ColorHex("#7d69ac".to_string())),
+                colors: Some(ChartViewBarsColors {
+                    fill: Some(ChartElementColor {
+                        color_value: Some(ColorValue::ColorHex("#a496c4".to_string())),
+                    }),
+                    stroke: Some(ChartElementColor {
+                        color_value: Some(ColorValue::ColorHex("#7d69ac".to_string())),
+                    }),
                 }),
             }],
         }));
@@ -417,11 +419,13 @@ mod tests {
         view.values = Some(Values::BarsValues(ChartViewBarsValues {
             bars_datasets: vec![BarsDataset {
                 values: vec![64_f32, 32_f32],
-                fill_color: Some(ChartElementColor {
-                    color_value: Some(ColorValue::ColorHex("#028c02".to_string())),
-                }),
-                stroke_color: Some(ChartElementColor {
-                    color_value: Some(ColorValue::ColorHex("#02b502".to_string())),
+                colors: Some(ChartViewBarsColors {
+                    fill: Some(ChartElementColor {
+                        color_value: Some(ColorValue::ColorHex("#028c02".to_string())),
+                    }),
+                    stroke: Some(ChartElementColor {
+                        color_value: Some(ColorValue::ColorHex("#02b502".to_string())),
+                    }),
                 }),
             }],
         }));
@@ -447,11 +451,13 @@ mod tests {
         vertical_bar_view.values = Some(Values::BarsValues(ChartViewBarsValues {
             bars_datasets: vec![BarsDataset {
                 values: vec![20_f32, 200_f32],
-                fill_color: Some(ChartElementColor {
-                    color_value: Some(ColorValue::ColorHex("#cc6633".to_string())),
-                }),
-                stroke_color: Some(ChartElementColor {
-                    color_value: Some(ColorValue::ColorHex("#ff9933".to_string())),
+                colors: Some(ChartViewBarsColors {
+                    fill: Some(ChartElementColor {
+                        color_value: Some(ColorValue::ColorHex("#cc6633".to_string())),
+                    }),
+                    stroke: Some(ChartElementColor {
+                        color_value: Some(ColorValue::ColorHex("#ff9933".to_string())),
+                    }),
                 }),
             }],
         }));


### PR DESCRIPTION
Update protobufs and change colors usage.

Allow clippy::enum_variant_names linters since it warns only on
generated code and we allow such names because of protobuf fields names.