### PR TITLE
Added changelog and updated version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+## [0.2.0] - 2021-08-21
+
+### Added
+
+* Added `SIGINT` signal graceful shutdown handler
+* Updated `lc-proto` to `v0.4.0` and protobuf usage
+* Removed unused args from `Dockerfile`, added empty `CMD`, Rust version is set to `:1`
+
+## [0.1.0] - 2021-05-27
+
+### Added
+
+* Added `lc-proto` with scripts to download and build protobufs
+* Added `RendererError` enum that contains all application errors
+* Added helpers to convert scales, colors, view values, points, bar label positions from protobuf enums
+* Added helpers to create chart views from protobuf
+* Added `RendererServer` that implements `ChartRenderer` lc-proto service
+* Added workflows to lint and test code
+* Added `Dockerfile` and workflows to build and push images
+
+## [0.0.1] - 2021-05-18
+
+Initial release of the app that provides gRPC API to render chart images via `lc-render` library

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "lc-renderer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "lc-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lc-renderer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 authors = ["Andrei Ozerov <andrei.ozerov92@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ Server to render chart images
 
 ## API
 
-The server implements [GRPC](https://www.grpc.io) API of [lc-proto](https://github.com/limpidchart/lc-proto) `ChartRenderer` service.  
+The server implements [gRPC](https://www.grpc.io) API of [lc-proto](https://github.com/limpidchart/lc-proto) `ChartRenderer` service.  
 It performs only a very basic validation of input parameters.  
 Please use lc-api for complex validation and REST API.


### PR DESCRIPTION
Added changelog with all current versions.

Set version in `Cargo.toml` to `0.2.0`.

Fixed `GRPC` -> `gRPC` in readme.